### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+## Initial file creation


### PR DESCRIPTION
This PR adds a initial .gitignore file to prevent unnecessary files (e.g., node_modules/, build files, and environment configs) from being tracked in the repository. The content will be defined at a later stage.