### PR TITLE
Fixed bug in GUI behavior where the footer hid content.

### DIFF
--- a/App/city-feedback/src/main/resources/static/styles.css
+++ b/App/city-feedback/src/main/resources/static/styles.css
@@ -1,6 +1,16 @@
 h2 {
     background: green;
+    margin-bottom: 0.5rem;
 }
+
 header {
     background-color: indianred;
+}
+
+.btn {
+    margin: 0.7rem 0 2rem 0;
+}
+
+footer {
+    margin-top: auto;
 }

--- a/App/city-feedback/src/main/resources/static/styles.css
+++ b/App/city-feedback/src/main/resources/static/styles.css
@@ -1,16 +1,11 @@
 h2 {
     background: green;
-    margin-bottom: 0.5rem;
 }
 
 header {
     background-color: indianred;
 }
 
-.btn {
-    margin: 0.7rem 0 2rem 0;
-}
-
-footer {
-    margin-top: auto;
+.form-group button[type="submit"] {
+    margin: 0.5rem 0 0.5rem 0;
 }

--- a/App/city-feedback/src/main/resources/templates/fragments/footer.html
+++ b/App/city-feedback/src/main/resources/templates/fragments/footer.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <div th:fragment="footer">
-      <footer class="bg-dark text-center text-white fixed-bottom">
+      <footer class="bg-dark text-center text-white">
           <div class="container p-4 pb-0">
               <section class="mb-4">
                   <a class="btn btn-outline-light btn-floating m-1" href="#" role="button"><i class="fab fa-facebook-f"></i></a>

--- a/App/city-feedback/src/main/resources/templates/layout.html
+++ b/App/city-feedback/src/main/resources/templates/layout.html
@@ -12,13 +12,13 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.5/font/bootstrap-icons.min.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   </head>
-  <body>
-    <header>
+  <body class="d-flex flex-column min-vh-100">
+    <header class="bg-dark text-light">
       <div th:replace="~{fragments/header.html}"></div>
     </header>
 
     <!-- Main content area where child pages will inject content -->
-    <main layout:fragment="content"></main>
+    <main layout:fragment="content" class="flex-grow-1"></main>
 
     <footer>
       <div th:replace="~{fragments/footer.html}"></div>


### PR DESCRIPTION
- bug: when main content becomes longer, e.g. "Create complaint" form + Error feedback, the submit button was hid behind the footer.
- now the footer adjusts correctly when the main content becomes larger. Footer is pushed to the bottom only after the end of main content.